### PR TITLE
tensor size update for cifar-10 example

### DIFF
--- a/Deep Learning with Torch.ipynb
+++ b/Deep Learning with Torch.ipynb
@@ -542,7 +542,7 @@
       "\n",
       "__1. Load and normalize data__\n",
       "\n",
-      "Today, in the interest of time, we prepared the data before-hand into a 4D torch ByteTensor of size 10000x3x32x32 (training) and 10000x3x32x32 (testing)\n",
+      "Today, in the interest of time, we prepared the data before-hand into a 4D torch ByteTensor of size 50000x3x32x32 (training) and 10000x3x32x32 (testing)\n",
       "Let us load the data and inspect it."
      ]
     },


### PR DESCRIPTION
tensor size of training examples fixed in cifar-10 example
